### PR TITLE
chore: use crypto global

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,5 +42,6 @@
     "type-fest": "^4.10.2",
     "typescript": "^5.3.3",
     "vitest": "^1.2.2"
-  }
+  },
+  "packageManager": "pnpm@8.15.4+sha256.cea6d0bdf2de3a0549582da3983c70c92ffc577ff4410cbf190817ddc35137c2"
 }

--- a/packages/http-helmet/src/index.ts
+++ b/packages/http-helmet/src/index.ts
@@ -1,4 +1,4 @@
-export { mergeHeaders } from "./utils";
+export { createNonce, mergeHeaders } from "./utils";
 
 export type {
   ContentSecurityPolicy,

--- a/packages/http-helmet/src/react.tsx
+++ b/packages/http-helmet/src/react.tsx
@@ -1,5 +1,3 @@
-import nodeCrypto from "node:crypto";
-// eslint-disable-next-line import/no-extraneous-dependencies
 import * as React from "react";
 
 let NonceContext = React.createContext<string | undefined>(undefined);
@@ -17,11 +15,4 @@ export function NonceProvider({ nonce, children }: NonceProviderProps) {
 
 export function useNonce(): string | undefined {
   return React.useContext(NonceContext);
-}
-
-export function createNonce(): string {
-  if ("randomUUID" in crypto) {
-    return Buffer.from(crypto.randomUUID()).toString("hex");
-  }
-  return nodeCrypto.randomBytes(16).toString("hex");
 }

--- a/packages/http-helmet/src/utils.ts
+++ b/packages/http-helmet/src/utils.ts
@@ -51,3 +51,7 @@ export function mergeHeaders(...sources: HeadersInit[]): Headers {
 
   return new Headers(result);
 }
+
+export function createNonce(): string {
+  return Buffer.from(crypto.randomUUID()).toString("hex");
+}

--- a/packages/http-helmet/tsup.config.ts
+++ b/packages/http-helmet/tsup.config.ts
@@ -1,27 +1,16 @@
 import { defineConfig } from "tsup";
-import type { Options } from "tsup";
 import pkgJson from "./package.json";
 
 let external = Object.keys(pkgJson.dependencies || {});
 
-export default defineConfig(() => {
-  let options: Options = {
-    shims: true,
-    entry: ["src/index.ts", "src/react.tsx"],
-    sourcemap: true,
-    external,
-    tsconfig: "./tsconfig.json",
-    dts: true,
-  };
-
-  return [
-    {
-      ...options,
-      format: "cjs",
-    },
-    {
-      ...options,
-      format: "esm",
-    },
-  ];
+export default defineConfig({
+  shims: true,
+  entry: ["src/index.ts", "src/react.tsx"],
+  sourcemap: true,
+  external,
+  tsconfig: "./tsconfig.json",
+  dts: true,
+  target: "es2022",
+  clean: true,
+  format: ["cjs", "esm"],
 });


### PR DESCRIPTION
~we depend on node 18 which already has it so we dont need to feature detect it~
node 19 has global `crypto.randomUUID` - welp

Signed-off-by: Logan McAnsh <logan@mcan.sh>
